### PR TITLE
fix(bytes): read the correct number of bytes for 4 tag

### DIFF
--- a/src/stream.ts
+++ b/src/stream.ts
@@ -418,15 +418,15 @@ export class TypedStreamReader implements Iterator<ReadEvent> {
         } else if (head == TAG_INTEGER_4) {
             if (this.byteOrder == "LE") {
                 if (signed) {
-                    return this.readExact(2).readInt32LE();
+                    return this.readExact(4).readInt32LE();
                 } else {
-                    return this.readExact(2).readUint32LE();
+                    return this.readExact(4).readUint32LE();
                 }
             } else {
                 if (signed) {
-                    return this.readExact(2).readInt32BE();
+                    return this.readExact(4).readInt32BE();
                 } else {
-                    return this.readExact(2).readUint32BE();
+                    return this.readExact(4).readUint32BE();
                 }
             }
         } else {


### PR DESCRIPTION
Fixes https://github.com/BlueBubblesApp/node-typedstream/issues/1